### PR TITLE
Smarter Log Selection

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,6 @@
 use std::{env, time::Duration};
 
-use burrito::burrito::{burrito_cfg::BurritoCfg, burrito_data::BurritoData, systems::SystemContext, log_watcher::{EventType, LogWatcher}, log_reader::LogReader};
+use burrito::burrito::{burrito_cfg::BurritoCfg, burrito_data::BurritoData, systems::SystemContext, log_watcher::{EventType, LogWatcher, self}, log_reader::LogReader};
 use burrito::burrito::systems;
 use burrito::burrito::alert;
 
@@ -26,22 +26,15 @@ fn main() {
 fn run_burrito(ctx: SystemContext, cfg: BurritoCfg, data: BurritoData) {
     let sys_map = systems::load_saved_system_map();
     // TODO: add some way to configure this with files or arguments
-    let mut chat_watcher = LogWatcher::new(
+    let mut log_watcher = LogWatcher::new(
         ctx.clone(),
         cfg.clone(),
         data.clone(),
-        create_chat_log_readers(&cfg),
         sys_map.clone(),
     );
-    let mut game_watcher = LogWatcher::new(
-        ctx.clone(),
-        cfg.clone(),
-        data.clone(),
-        create_game_log_readers(&cfg),
-        sys_map.clone(),
-    );
+    log_watcher.init();
     loop {
-        chat_watcher.get_events().into_iter().for_each(|event| {
+        log_watcher.get_events().into_iter().for_each(|event| {
             println!("{}", &event.trigger);
             match event.event_type {
                 EventType::NeutInRange(event_distance) => {
@@ -54,11 +47,6 @@ fn run_burrito(ctx: SystemContext, cfg: BurritoCfg, data: BurritoData) {
                         }
                     }
                 },
-                _ => {}// TODO: The rest of the events
-            }
-        });
-        for event in game_watcher.get_events() {
-            match event.event_type {
                 EventType::FactionSpawn => {
                     if let Some(audio_alert) = cfg.sound_config.audio_alerts.iter()
                         .find(|a| a.trigger == event.event_type) {
@@ -79,19 +67,7 @@ fn run_burrito(ctx: SystemContext, cfg: BurritoCfg, data: BurritoData) {
                 },
                 _ => {}// TODO: The rest of the events
             }
-        }
+        });
         std::thread::sleep(Duration::from_millis(cfg.log_update_interval_ms))
     }
-}
-
-fn create_chat_log_readers(cfg: &BurritoCfg) -> Vec<LogReader> {
-    let mut log_readers: Vec<LogReader> = vec![];
-    cfg.text_channel_config.text_channels.iter().for_each(|c| {
-        log_readers.push(LogReader::new_intel_reader(cfg.clone(), c.clone()));
-    });
-    log_readers
-}
-
-fn create_game_log_readers(cfg: &BurritoCfg) -> Vec<LogReader> {
-    LogReader::new_game_log_readers(cfg.clone(), cfg.num_game_log_readers)
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,6 +1,6 @@
 use std::{env, time::Duration};
 
-use burrito::burrito::{burrito_cfg::BurritoCfg, burrito_data::BurritoData, systems::SystemContext, log_watcher::{EventType, LogWatcher, self}, log_reader::LogReader};
+use burrito::burrito::{burrito_cfg::BurritoCfg, burrito_data::BurritoData, systems::SystemContext, log_watcher::{EventType, LogWatcher}};
 use burrito::burrito::systems;
 use burrito::burrito::alert;
 

--- a/src/burrito/bloom_filter.rs
+++ b/src/burrito/bloom_filter.rs
@@ -1,0 +1,50 @@
+use std::{collections::{hash_map::DefaultHasher, HashSet}, hash::{Hash, Hasher}};
+
+#[derive(Clone)]
+pub struct BloomFilter {
+    hashes: HashSet<u64>,
+}
+
+impl Default for BloomFilter {
+    fn default() -> Self {
+        Self {
+            hashes: HashSet::new(),
+        }
+    }
+}
+
+impl BloomFilter {
+    pub fn insert<T: Hash>(&mut self, item: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        item.hash(&mut hasher);
+        let hash = hasher.finish();
+        self.hashes.insert(hash);
+        hash
+    }
+    
+    pub fn probably_contains<T: Hash>(&self, item: &T) -> bool {
+        let mut hasher = DefaultHasher::new();
+        item.hash(&mut hasher);
+        let hash = hasher.finish();
+        self.hashes.contains(&hash)
+    }
+
+    pub fn new() -> Self {
+        BloomFilter::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BloomFilter;
+
+    #[test]
+    fn test_bloom_filter() {
+        let mut uut = BloomFilter::new();
+        assert!(!uut.probably_contains(&"ur mom".to_owned()));
+        uut.insert(&"ur mom".to_owned());
+        assert!(uut.probably_contains(&"ur mom".to_owned()));
+        assert!(!uut.probably_contains(&"ur dad".to_owned()));
+    }
+
+}

--- a/src/burrito/bloom_filter.rs
+++ b/src/burrito/bloom_filter.rs
@@ -29,6 +29,10 @@ impl BloomFilter {
         self.hashes.contains(&hash)
     }
 
+    pub fn clear(&mut self) {
+        self.hashes.clear();
+    }
+
     pub fn new() -> Self {
         BloomFilter::default()
     }

--- a/src/burrito/burrito_cfg.rs
+++ b/src/burrito/burrito_cfg.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashSet};
 
 use serde_derive::{Deserialize, Serialize};
 
-use super::{log_watcher::EventType, serde_utils, utils, log_reader::IntelChannel};
+use super::{log_watcher::EventType, serde_utils, utils, log_watcher::IntelChannel};
 
 #[derive(Clone, Deserialize, Serialize)]
 pub struct BurritoCfg {

--- a/src/burrito/burrito_cfg.rs
+++ b/src/burrito/burrito_cfg.rs
@@ -34,7 +34,7 @@ impl Default for BurritoCfg {
             log_dir: format!("{}/Documents/Eve/logs/", utils::get_home_dir()).to_owned(),
             log_update_interval_ms: 500,
             game_log_alert_cd_ms: 5000,
-            recent_post_cache_ttl_ms: 10000,
+            recent_post_cache_ttl_ms: 30000,
             sound_config: Default::default(),
             text_channel_config: Default::default(),
         }

--- a/src/burrito/burrito_cfg.rs
+++ b/src/burrito/burrito_cfg.rs
@@ -13,7 +13,7 @@ pub struct BurritoCfg {
     #[serde(default)]
     pub game_log_alert_cd_ms: u64,
     #[serde(default)]
-    pub recent_post_cache_ttl_ms: u64,
+    pub recent_post_cache_ttl_ms: i64,
     #[serde(default)]
     pub sound_config: AudioAlertConfig,
     #[serde(default)]

--- a/src/burrito/burrito_cfg.rs
+++ b/src/burrito/burrito_cfg.rs
@@ -11,9 +11,9 @@ pub struct BurritoCfg {
     #[serde(default)]
     pub log_update_interval_ms: u64,
     #[serde(default)]
-    pub num_game_log_readers: usize,
-    #[serde(default)]
     pub game_log_alert_cd_ms: u64,
+    #[serde(default)]
+    pub recent_post_cache_ttl_ms: u64,
     #[serde(default)]
     pub sound_config: AudioAlertConfig,
     #[serde(default)]
@@ -33,8 +33,8 @@ impl Default for BurritoCfg {
         Self {
             log_dir: format!("{}/Documents/Eve/logs/", utils::get_home_dir()).to_owned(),
             log_update_interval_ms: 500,
-            num_game_log_readers: 10,
             game_log_alert_cd_ms: 5000,
+            recent_post_cache_ttl_ms: 10000,
             sound_config: Default::default(),
             text_channel_config: Default::default(),
         }

--- a/src/burrito/log_reader.rs
+++ b/src/burrito/log_reader.rs
@@ -66,6 +66,11 @@ impl LogReader {
     pub fn get_character_name(&self) -> String {
         self.character_name.to_owned()
     }
+
+    pub fn get_log_file(&self) -> String {
+        self.log_file.to_owned()
+    }
+
 }
 
 fn extract_listener(log_reader: &mut LogReader) {

--- a/src/burrito/log_reader.rs
+++ b/src/burrito/log_reader.rs
@@ -6,39 +6,52 @@ use regex::Regex;
 use serde_derive::{Deserialize, Serialize};
 
 const LISTENER_REGEX: &str = r#"\s{1,}Listener:\s{1,}(?<listener>[A-z ]{1,})"#;
+const CHANNEL_REGEX: &str = r#"\s{1,}Channel Name:\s{1,}(?<channel>.{1,})"#;
 
 // TODO: LogReader should probably be a trait and chat and game log readers should be different implementations
 #[derive(Clone, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 pub struct LogReader {
     character_name: String,
+    channel_name: String,
     log_file: String,
     cursor: usize,
     is_chatlog_reader: bool,
+    last_updated_timestamp_ms: u64,
+    active: bool,
 }
 
 impl LogReader {
+
     pub fn new_chatlog_reader(file: &str) -> Self {
         let mut log_reader =
             Self {
                 character_name: String::new(),
+                channel_name: String::new(),
                 log_file: file.to_owned(),
                 cursor: 0usize,
                 is_chatlog_reader: true,
+                last_updated_timestamp_ms: 0,
+                active: true,
             };
-        extract_listener(&mut log_reader);
+        extract_channel_info(&mut log_reader);
         log_reader
     }
+
     pub fn new_gamelog_reader(file: &str) -> Self {
         let mut log_reader =
             Self {
                 character_name: String::new(),
+                channel_name: String::new(),
                 log_file: file.to_owned(),
                 cursor: 0usize,
                 is_chatlog_reader: false,
+                last_updated_timestamp_ms: 0,
+                active: true,
             };
-        extract_listener(&mut log_reader);
+        extract_channel_info(&mut log_reader);
         log_reader
     }
+
     pub fn read_to_end(&mut self) -> LogReadResult {
         let mut lines: Vec<String> = vec![];
         let f = File::open(&self.log_file).unwrap();
@@ -57,12 +70,15 @@ impl LogReader {
             for line in data.trim().split("\r\n") {
                 lines.push(line.to_string());
             }
+            self.last_updated_timestamp_ms = chrono::offset::Utc::now().timestamp_millis() as u64;
         }
         return LogReadResult { bytes_read: read, lines: lines };
     }
+
     pub fn is_chatlog_reader(&self) -> bool {
         self.is_chatlog_reader
     }
+
     pub fn get_character_name(&self) -> String {
         self.character_name.to_owned()
     }
@@ -73,13 +89,16 @@ impl LogReader {
 
 }
 
-fn extract_listener(log_reader: &mut LogReader) {
-    let regex = Regex::new(LISTENER_REGEX).unwrap();
+fn extract_channel_info(log_reader: &mut LogReader) {
+    let listener_regex = Regex::new(LISTENER_REGEX).unwrap();
+    let channel_regex = Regex::new(CHANNEL_REGEX).unwrap();
     let result = log_reader.read_to_end();
     for line in result.lines {
-        if let Some(cap) = regex.captures(&line) {
+        if let Some(cap) = listener_regex.captures(&line) {
             log_reader.character_name = cap["listener"].to_owned();
-            break;
+        }
+        if let Some(cap) = channel_regex.captures(&line) {
+            log_reader.channel_name = cap["channel"].to_owned();
         }
     }
 }

--- a/src/burrito/log_watcher.rs
+++ b/src/burrito/log_watcher.rs
@@ -56,18 +56,16 @@ impl LogWatcher {
         let new_log_readers = self.create_new_log_readers();
         self.log_readers.extend(new_log_readers);
         let mut events = LogEventQueue::new(self.cfg.game_log_alert_cd_ms);
+        // TODO: This might be OK, but maybe this filter should persist for 2 or 3 cycles instead of 1?
         let mut chat_lines_to_skip = BloomFilter::new();
         for reader in &mut self.log_readers {
             let result = reader.read_to_end();
             for line in result.lines {
                 if reader.is_chatlog_reader() {
-                    eprintln!("line: {}", &line);
                     if chat_lines_to_skip.probably_contains(&line) {
-                        eprintln!("Already in filter, skipping");
                         continue;
                     }
                     else {
-                        eprintln!("Not in filter, adding");
                         chat_lines_to_skip.insert(&line);
                     }
                 }

--- a/src/burrito/mod.rs
+++ b/src/burrito/mod.rs
@@ -1,5 +1,6 @@
 
 pub mod alert;
+pub mod bloom_filter;
 pub mod burrito_cfg;
 pub mod burrito_data;
 pub mod json_struct;

--- a/src/burrito/path_cache.rs
+++ b/src/burrito/path_cache.rs
@@ -17,6 +17,7 @@ impl PathCache {
     pub fn search(&mut self, key: &(SystemId, SystemId)) -> Option<Distance> {
         let opposite_key = (key.1, key.0);
         let mut new_key = key.to_owned();
+        // TODO: this is a little ugly and is a warning. Rewrite this a bit better and more readable
         let mut new_entry:PathCacheEntry = Default::default();
         if let Some(entry) = self.path_cache.get(&opposite_key) {
             // Old entry with opposite key exists. Update it
@@ -100,5 +101,55 @@ impl Ord for PathCacheEntry {
 impl PartialOrd for PathCacheEntry {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.last_updated_ms.partial_cmp(&other.last_updated_ms)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PathCache;
+    use super::PathCacheEntry;
+    use super::Distance;
+
+    #[test]
+    fn test_ord_for_path_cache_entry() {
+        let mut uut_old = PathCacheEntry {
+            distance: Distance::Route { route: 3 },
+            last_updated_ms: 0
+        };
+        let mut uut_new = PathCacheEntry {
+            distance: Distance::Route { route: 3 },
+            last_updated_ms: 1
+        };
+        assert!(uut_new > uut_old);
+
+        uut_new.distance = Distance::Route { route: 1 };
+        assert!(uut_new > uut_old);
+
+        uut_new.distance = Distance::Route { route: 5 };
+        assert!(uut_new > uut_old);
+
+        uut_new.distance = Distance::RouteFetchErr;
+        assert!(uut_new > uut_old);
+
+        uut_new.distance = Distance::NoRoute;
+        assert!(uut_new > uut_old);
+
+        uut_old.distance = Distance::Route { route: 1 };
+        assert!(uut_new > uut_old);
+
+        uut_old.distance = Distance::Route { route: 5 };
+        assert!(uut_new > uut_old);
+
+        uut_old.distance = Distance::RouteFetchErr;
+        assert!(uut_new > uut_old);
+
+        uut_old.distance = Distance::NoRoute;
+        assert!(uut_new > uut_old);
+    }
+
+    #[test]
+    fn test_persistent_path_cache() {
+        let /*mut*/ _uut = PathCache::default();
+        // TODO: this
     }
 }

--- a/src/burrito/systems.rs
+++ b/src/burrito/systems.rs
@@ -17,6 +17,18 @@ impl std::fmt::Display for SystemId {
     }
 }
 
+impl From<SystemId> for u64 {
+    fn from(sys_id: SystemId) -> Self {
+        sys_id.0
+    }
+}
+
+impl From<u64> for SystemId {
+    fn from(value: u64) -> Self {
+        SystemId(value)
+    }
+}
+
 #[serde_as]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct SystemContext {


### PR DESCRIPTION
Creating new LogReaders for dead logs especially is really cheap. Instead of only creating LogReaders on start, ignore all logs at startup and let LogWatcher create new LogReaders every time a new log appears. For gamelogs this just works. For chatlogs, it's a bit more complicated. Users running multiple clients may have all their clients in intel channels. To avoid duplicate events from multiple clients, use a ttl cache for sender/message pairs.