### PR TITLE
Watch recent logs on launch

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,6 @@
 @ECHO OFF
-set burrito_dir=%HOMEPATH%/.burrito
+set burrito_dir=%HOMEPATH%\.burrito
 mkdir burrito_dir
-xcopy data/sounds %burrito_dir%
-copy data/systems.json %burrito_dir%
+xcopy data\sounds %burrito_dir%
+copy data\systems.json %burrito_dir%
 copy burrito.exe %HOMEPATH%


### PR DESCRIPTION
On launching Burrito, Burrito will open all configured logs that have been updated recently. This does lead to some read logs being watched, but the cost of this is very low. The benefit of this is that the order of opening Burrito and Eve clients will not matter. Burrito can be opened before or after clients and it does not matter if either client(s) or Burrito needs to be restarted at any point. Burrito will always watch the logs that it needs to.