### PR TITLE
Replace route fetching with offline pathfinding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ encoding_rs = "0.8.32"
 encoding_rs_io = "0.1.7"
 home = "0.5.3"
 regex = "1.9.1"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
 rodio = "0.17.1"
 serde = "1.0.169"
 serde_derive = "1.0.171"
@@ -19,3 +18,7 @@ serde_with = { version = "3.0.0", features = ["json"] }
 strum = "0.25"
 strum_macros = "0.25"
 termcolor = "1.2.0"
+
+[dev-dependencies]
+
+rand = "0.8.5"


### PR DESCRIPTION
ESI route fetching gives very bad results in some cases. It is also slow and adds network dependencies to Burrito. Replacing the ESI route fetching system with a fully-offline, optimized BFS algorithm gives results that are at least as good but often better and always faster than the old API system. Attached is a test using the ESI API vs the new offline pathfinding with several randomly selected systems. In no cases did the ESI route API perform better than the offline system.
[offline_pathfinding_results.txt](https://github.com/Burrito-Devs/burrito/files/12657233/offline_pathfinding_results.txt)
