### PR TITLE
Refetch Channel Info

### DIFF
--- a/src/burrito/log_reader.rs
+++ b/src/burrito/log_reader.rs
@@ -46,30 +46,16 @@ impl LogReader {
         log_reader
     }
 
-    // TODO: refactor this. Make read function extract listener/channel if still blank
-    pub fn read_to_end(&mut self) -> LogReadResult {
+    pub fn read_new_lines(&mut self) -> LogReadResult {
         if self.character_name.len() == 0 || self.channel_name.len() == 0 {
             extract_channel_info(self);
         }
-        let mut lines: Vec<String> = vec![];
         let f = File::open(&self.log_file).expect(&format!("Failed to open {}", self.log_file));
         let mut reader = BufReader::new(f);
         _ = reader.seek(SeekFrom::Start(self.cursor as u64));
-        let mut buffer = vec![];
-        let read = reader.read_to_end(&mut buffer).unwrap();
-        if read > 0 {
-            let (data, _, _) = if self.is_chatlog_reader() {
-                UTF_16LE.decode(&buffer)
-            }
-            else {
-                UTF_8.decode(&buffer)
-            };
-            self.cursor += read;
-            for line in data.trim().split("\r\n") {
-                lines.push(line.to_string());
-            }
-        }
-        return LogReadResult { bytes_read: read, lines: lines };
+        let read_result = read_to_end(&mut reader, self.is_chatlog_reader);
+        self.cursor += read_result.bytes_read;
+        return read_result;
     }
 
     pub fn is_chatlog_reader(&self) -> bool {
@@ -86,16 +72,12 @@ impl LogReader {
 
 }
 
-fn extract_channel_info(log_reader: &mut LogReader) {
-    let listener_regex = Regex::new(LISTENER_REGEX).unwrap();
-    let channel_regex = Regex::new(CHANNEL_REGEX).unwrap();
+fn read_to_end(buf_reader: &mut BufReader<File>, is_chatlog: bool) -> LogReadResult {
     let mut lines: Vec<String> = vec![];
-    let f = File::open(&log_reader.log_file).expect(&format!("Failed to open {}", log_reader.log_file));
-    let mut buf_reader = BufReader::new(f);
     let mut buffer = vec![];
     let read = buf_reader.read_to_end(&mut buffer).unwrap();
     if read > 0 {
-        let (data, _, _) = if log_reader.is_chatlog_reader() {
+        let (data, _, _) = if is_chatlog {
             UTF_16LE.decode(&buffer)
         }
         else {
@@ -105,8 +87,16 @@ fn extract_channel_info(log_reader: &mut LogReader) {
             lines.push(line.to_string());
         }
     }
-    let result = LogReadResult { bytes_read: read, lines: lines };
-    for line in result.lines {
+    return LogReadResult { bytes_read: read, lines: lines };
+}
+
+fn extract_channel_info(log_reader: &mut LogReader) {
+    let listener_regex = Regex::new(LISTENER_REGEX).unwrap();
+    let channel_regex = Regex::new(CHANNEL_REGEX).unwrap();
+    let f = File::open(&log_reader.log_file).expect(&format!("Failed to open {}", log_reader.log_file));
+    let mut buf_reader = BufReader::new(f);
+    let read_result = read_to_end(&mut buf_reader, log_reader.is_chatlog_reader);
+    for line in read_result.lines {
         if let Some(cap) = listener_regex.captures(&line) {
             log_reader.character_name = cap["listener"].to_owned();
         }

--- a/src/burrito/log_watcher.rs
+++ b/src/burrito/log_watcher.rs
@@ -62,7 +62,6 @@ impl LogWatcher {
         self.ignore_old_logs_and_watch_recent();
     }
 
-    // TODO: test this case again [ 2023.11.12 12:08:18 ] Echuu Shan-jan > 7G-QIG status ?
     pub fn get_events(&mut self) -> Vec<LogEvent> {
         let new_log_readers = self.update_log_readers();
         self.log_readers.extend(new_log_readers);

--- a/src/burrito/log_watcher.rs
+++ b/src/burrito/log_watcher.rs
@@ -62,7 +62,8 @@ impl LogWatcher {
         self.ignore_old_logs_and_watch_recent();
     }
 
-    pub fn get_events(&mut self) -> Vec<LogEvent> {// TODO: Fix game log cooldown logic
+    // TODO: test this case again [ 2023.11.12 12:08:18 ] Echuu Shan-jan > 7G-QIG status ?
+    pub fn get_events(&mut self) -> Vec<LogEvent> {
         let new_log_readers = self.update_log_readers();
         self.log_readers.extend(new_log_readers);
         let event_time = chrono::offset::Utc::now();
@@ -126,6 +127,7 @@ impl LogWatcher {
                                 if let Some(result) = results.iter().next() {
                                     let d = result.0.get_route();
                                     let content_lower = content.to_lowercase().replace("?", "").replace(".", "");
+                                    let content_lower = content_lower.trim();
                                     if content_lower.ends_with("clr") || content_lower.ends_with("clear") {
                                         event_type = EventType::SystemClear(d);
                                         message = format!("System clear!");

--- a/src/burrito/log_watcher.rs
+++ b/src/burrito/log_watcher.rs
@@ -69,7 +69,7 @@ impl LogWatcher {
         let event_time = chrono::offset::Utc::now();
         self.update_recent_post_cache(event_time.timestamp_millis());
         for reader in &mut self.log_readers {
-            let result = reader.read_to_end();
+            let result = reader.read_new_lines();
             for line in result.lines {
                 // TODO: eve time is out of sync with Rust time by like half a minute
                 /*let ts_regex = Regex::new(TIMESTAMP_REGEX).unwrap();
@@ -239,7 +239,7 @@ impl LogWatcher {
                     file_path.push_str(&filename);
                     let mut game_log_reader =
                         LogReader::new_gamelog_reader(&file_path);
-                    _ = game_log_reader.read_to_end();
+                    _ = game_log_reader.read_new_lines();
                     readers.push(game_log_reader);
                 }
             }
@@ -258,7 +258,7 @@ impl LogWatcher {
                         file_path.push_str(&filename);
                         let mut chat_log_reader =
                             LogReader::new_chatlog_reader(&file_path);
-                        _ = chat_log_reader.read_to_end();
+                        _ = chat_log_reader.read_new_lines();
                         readers.push(chat_log_reader);
                     }
                 }
@@ -283,7 +283,7 @@ impl LogWatcher {
                     file_path.push_str(&filename);
                     let mut game_log_reader =
                         LogReader::new_gamelog_reader(&file_path);
-                    _ = game_log_reader.read_to_end();
+                    _ = game_log_reader.read_new_lines();
                     self.log_readers.push(game_log_reader);
                 }
             }
@@ -301,7 +301,7 @@ impl LogWatcher {
                         file_path.push_str(&filename);
                         let mut chat_log_reader =
                             LogReader::new_chatlog_reader(&file_path);
-                        _ = chat_log_reader.read_to_end();
+                        _ = chat_log_reader.read_new_lines();
                         self.log_readers.push(chat_log_reader);
                     }
                 });

--- a/src/burrito/path_cache.rs
+++ b/src/burrito/path_cache.rs
@@ -19,7 +19,7 @@ impl PathCache {
         let opposite_key = (key.1, key.0);
         let mut new_key = key.to_owned();
         // TODO: this is a little ugly and is a warning. Rewrite this a bit better and more readable
-        let mut new_entry:PathCacheEntry = Default::default();
+        let mut new_entry;
         if let Some(entry) = self.path_cache.get(&opposite_key) {
             // Old entry with opposite key exists. Update it
             new_key = opposite_key;


### PR DESCRIPTION
Some users with dozens of accounts have seen an issue with Eve clients where the character name information is not available in the log  at the time messages start appearing in game logs. This wasn't thought to be possible except in rare cases such as creating a new character. Since it seems it can happen when running dozens of clients and/or using isboxer, logic needs to be added to handle this. So each time a LogReader is polled, it will recheck channel+character name if either is still blank. If so, another attempt to parse this information will be performed. After, new messages will be returned regardless of whether or not obtaining the channel information was successful.